### PR TITLE
WIP: Catch errors on file open and print error message

### DIFF
--- a/part3_neural_network_mnist_and_own_data.ipynb
+++ b/part3_neural_network_mnist_and_own_data.ipynb
@@ -141,12 +141,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "# load the mnist training data CSV file into a list\n",
-    "training_data_file = open(\"mnist_dataset/mnist_train.csv\", 'r')\n",
+    "try:\n",
+    "    training_data_file = open(\"mnist_dataset/mnist_train.csv\", 'r')\n",
+    "except FileNotFoundError:\n",
+    "    print('Unable to open training file. Did you forget to download the full training set from https://pjreddie.com/projects/mnist-in-csv/?')\n",
+    "    raise\n",
     "training_data_list = training_data_file.readlines()\n",
     "training_data_file.close()"
    ]
@@ -321,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
What about adding this check to all places where one of the original MNIST files gets opened. It might not only happen to me that one forgets to download the files and then wonders what's going wrong here and why the filenames do not correspond to those present in the "mnist_dataset" folder.

If you are Ok with this I would extend this merge request to other occurrences.